### PR TITLE
Enhanced name randomizer with more features (leet, separator) and a bug fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -672,6 +672,11 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
+    "yargs-parser": {
+      "version": "19.0.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-19.0.1.tgz",
+      "integrity": "sha512-2UuJKZmPN9S9/0s3FSCG3aNUSyC/qz56oJsMZG0NV2B44QxTXaNySp4xXW10CizmUs0DXgPY0y114dOGLvtYHg=="
+    },
     "zlib-sync": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/zlib-sync/-/zlib-sync-0.1.7.tgz",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "erlpack": "^0.1.3",
     "libsodium-wrappers": "^0.7.6",
     "utf-8-validate": "^5.0.2",
+    "yargs-parser": "^19.0.1",
     "zlib-sync": "^0.1.7"
   },
   "devDependencies": {

--- a/src/discord/name-gen.ts
+++ b/src/discord/name-gen.ts
@@ -1,6 +1,9 @@
 import adjNoun from 'adj-noun'
 import parser from 'yargs-parser'
+
 // const { ArgumentParser } = require('argparse');
+
+const SEED_RANGE = 2147483648; // must be significantly smaller than Number.MAX_SAFE_INTEGER or adj-noun may give undefined stuff on fractional values
 
 // const parser = new ArgumentParser({
 //     description: 'Username generator'
@@ -9,6 +12,7 @@ import parser from 'yargs-parser'
 // parser.add_argument('--leet', { action: "store_true", help: "Make your username l33t" })
 
 export function generateName(commandArgs: string[]): string {
+    adjNoun.seed(Math.floor(Math.random() * SEED_RANGE))
     // let args = parser.parse_args(commandArgs.slice(1))
     let args = parser(commandArgs.slice(1), {
         default: { leet: false, separator: ' ' },

--- a/src/discord/name-gen.ts
+++ b/src/discord/name-gen.ts
@@ -1,6 +1,51 @@
-const adjNoun = require('adj-noun');
+import adjNoun from 'adj-noun'
+import parser from 'yargs-parser'
+// const { ArgumentParser } = require('argparse');
+
+// const parser = new ArgumentParser({
+//     description: 'Username generator'
+// });
+
+// parser.add_argument('--leet', { action: "store_true", help: "Make your username l33t" })
 
 export function generateName(commandArgs: string[]): string {
+    // let args = parser.parse_args(commandArgs.slice(1))
+    let args = parser(commandArgs.slice(1), {
+        default: { leet: false, separator: ' ' },
+        boolean: ['leet'],
+        string: ['separator'],
+    })
+    // let remaindingArgs: [] = args._
+    // if (remaindingArgs.length != 0) {
+    //     console.log(`Unrecognized arguments: ${remaindingArgs.join(' ')}`) // TODO throw exception in this case
+    // }
     let name: string[] = adjNoun();
-    return name.join(' ')
+    if (args.leet) {
+        for (let i = 0; i < name.length; i++) {
+            name[i] = leetify(name[i], 1);
+        }
+    }
+    return name.join(args.separator)
+}
+
+const leetTable = new Map([
+    ['a', '4'],
+    ['e', '3'],
+    ['i', '1'],
+    ['o', '0'],
+    ['s', '5'],
+])
+
+function leetify(s: string, coverage: number): string {
+    let result: string[] = [];
+    for (const char of s) {
+        let newchar: string;
+        if (Math.random() < coverage && leetTable.has(char)) {
+            newchar = leetTable.get(char)
+        } else {
+            newchar = char
+        }
+        result.push(newchar)
+    }
+    return result.join('')
 }


### PR DESCRIPTION
These commits added command line parameters (using a new dependency [`yargs-parser`](https://www.npmjs.com/package/yargs-parser)) to the name generator:

- `--leet` `[boolean]`: a flag to make names l33t by transforming letters into numbers, such as "dystopian algaecide" -> "dy5t0p14n 4lg43c1d3"
- `--separator` `[string]`: allow users to customize their separator between names, such as using dashes instead of spaces.

Example interaction:
![image](https://user-images.githubusercontent.com/32375681/90439381-52f33280-e08a-11ea-8d2d-23c95e8b90ca.png)

A bug is fixed which caused the names generated to be deterministic, see my commit message for details.
