### PR TITLE
Remove square brackets on help messages involving mandatory arguments

### DIFF
--- a/src/discord/command-strings.ts
+++ b/src/discord/command-strings.ts
@@ -4,7 +4,7 @@ export default [
     fields: [
       {
         name: 'Usage:',
-        value: '```-toolkit [category] ```or ```-tk [category]```\n',
+        value: '```-toolkit CATEGORY ```or ```-tk CATEGORY```\n',
       },
       {
         name: 'Description',
@@ -17,7 +17,7 @@ export default [
     fields: [
       {
         name: 'Usage:',
-        value: '```-flag [challenge name] [flag]```',
+        value: '```-flag CHALLENGE_NAME FLAG```',
       },
       {
         name: 'Description:',
@@ -30,7 +30,7 @@ export default [
     fields: [
       {
         name: 'Usage:',
-        value: '```-roleremove [role]```',
+        value: '```-roleremove ROLE```',
       },
       {
         name: 'Description',

--- a/src/discord/functions.ts
+++ b/src/discord/functions.ts
@@ -17,7 +17,11 @@ export const formatEmbed = ($embed: MessageEmbed) => {
 
 export const flag = async (db: Database<sqlite3.Database, sqlite3.Statement>, flagUsers: Set<User>, realFlag: Buffer, commandArgs: string[], message: Message, embed: MessageEmbed) => {
   if (commandArgs.length === 2) {
-    embed.setDescription('Please make sure to include both a flag **and** a challenge');
+    embed.setDescription('Please make sure to include the challenge name **as well as** the flag you get.');
+    return;
+  }
+  if (commandArgs.length > 3) {
+    embed.setDescription('Too many arguments provided. Please put exactly one flag after the challenge name.');
     return;
   }
   if (flagUsers.has(message.author)) {


### PR DESCRIPTION
In addition there's minor fixes on `-flag` command to align better with the help message