### PR TITLE
Name randomizer maintenance

### DIFF
--- a/src/discord/Bot.ts
+++ b/src/discord/Bot.ts
@@ -5,7 +5,7 @@ import sqlite3 from 'sqlite3';
 import { Database } from 'sqlite';
 import roles from './roles';
 import commands from './command-strings';
-import { generateName } from './name-gen';
+import generateName from './name-gen';
 import * as functions from './functions';
 import { channels, challenges, guildID } from '../config.json';
 
@@ -102,7 +102,8 @@ Remember you can only submit flags here in DM.`);
           functions.tk(commandString, reply);
           break;
         case 'name':
-          reply.setDescription(`What about this name:\n **${generateName(commandString)}**`);
+          generateName(commandString, reply);
+          // reply.setDescription(`What about this name:\n **${generateName(commandString)}**`);
           break;
         case 'help':
         case 'gettingstarted':

--- a/src/discord/command-strings.ts
+++ b/src/discord/command-strings.ts
@@ -81,4 +81,21 @@ export default [
       },
     ],
   },
+  {
+    name: 'name',
+    fields: [
+      {
+        name: 'Usage:',
+        value: '```-name [OPTIONS]...```',
+      },
+      {
+        name: 'Description:',
+        value: 'Generate a random username/handle for you in the format of _ADJECTIVE NOUN_ (Ex. silvery school).',
+      },
+      {
+        name: 'Options:',
+        value: '**--help**\nSee this help message\n**--leet**\nMake your username l33t\n**--separator** _SEPARATOR_\nWhat to put between adjectives and nouns\nEx. `-name --separator _`\nsilvery_school',
+      },
+    ],
+  },
 ];

--- a/src/discord/command-strings.ts
+++ b/src/discord/command-strings.ts
@@ -90,11 +90,25 @@ export default [
       },
       {
         name: 'Description:',
-        value: 'Generate a random username/handle for you in the format of _ADJECTIVE NOUN_ (Ex. silvery school).',
+        value: 'Generate a random username/handle for you in the format of _ADJECTIVE NOUN_. (Ex. silvery school)',
       },
       {
         name: 'Options:',
-        value: '**--help**\nSee this help message\n**--leet**\nMake your username l33t\n**--separator** _SEPARATOR_\nWhat to put between adjectives and nouns\nEx. `-name --separator _`\nsilvery_school',
+        value: `**--help**
+See this help message
+**--leet**
+Default: false
+Make your username l33t
+**--separator** _SEPARATOR_
+Default: [a single space character]
+What to put between adjectives and nouns
+Ex. \`-name --separator _\`
+silvery_school
+**--fraction-leet** _FRACTION_
+Default: 0.7
+A number between 0.0 and 1.0 (inclusive) that controls the probability that each convertible letter (a, e, i, o, s) will be converted into its corresponding digit.
+A higher number results in names that tend to have more digits in it, but it may lead to less readable names.
+This option has no effect when **--leet** is false`,
       },
     ],
   },

--- a/src/discord/name-gen.ts
+++ b/src/discord/name-gen.ts
@@ -4,41 +4,22 @@ import parser from 'yargs-parser';
 
 import commands from './command-strings';
 
-// const { ArgumentParser } = require('argparse');
-
 const SEED_RANGE = 2147483648; // must be significantly smaller than Number.MAX_SAFE_INTEGER or adj-noun may give undefined stuff on fractional values
 
-// const parser = new ArgumentParser({
-//     description: 'Username generator'
-// });
-
-// parser.add_argument('--leet', { action: "store_true", help: "Make your username l33t" })
-
-const leetTable = new Map([
+const LEET_TABLE = new Map([
   ['a', '4'],
   ['e', '3'],
   ['i', '1'],
   ['o', '0'],
   ['s', '5'],
 ]);
+const LEET_REPLACE_CHARS = /[aeios]/g;
 
-const leetify = (s: string, coverage: number): string => {
-  const result: string[] = [];
-  for (const char of s) {
-    let newchar: string;
-    if (Math.random() < coverage && leetTable.has(char)) {
-      newchar = leetTable.get(char);
-    } else {
-      newchar = char;
-    }
-    result.push(newchar);
-  }
-  return result.join('');
-};
+const leetify = (s: string, coverage: number) => s.replace(LEET_REPLACE_CHARS,
+  (char) => ((Math.random() < coverage) ? LEET_TABLE.get(char) : char));
 
 export default function generateName(commandArgs: string[], embed: MessageEmbed): void {
   adjNoun.seed(Math.floor(Math.random() * SEED_RANGE));
-  // let args = parser.parse_args(commandArgs.slice(1))
   const args = parser(commandArgs.slice(1), {
     default: { leet: false, help: false, separator: ' ' },
     boolean: ['leet', 'help'],
@@ -46,10 +27,10 @@ export default function generateName(commandArgs: string[], embed: MessageEmbed)
   });
   // let remaindingArgs: [] = args._
   // if (remaindingArgs.length != 0) {
-  //     console.log(`Unrecognized arguments: ${remaindingArgs.join(' ')}`) // TODO throw exception in this case
+  //     console.log(`Unrecognized arguments: ${remaindingArgs.join(' ')}`)
   // }
   let name: string[] = adjNoun();
-  if (args.help) {
+  if (args.help) { // Provide help message
     embed.addFields(commands.find((command) => command.name === 'name').fields);
     return;
   }

--- a/src/discord/name-gen.ts
+++ b/src/discord/name-gen.ts
@@ -1,5 +1,8 @@
+import { MessageEmbed } from 'discord.js';
 import adjNoun from 'adj-noun';
 import parser from 'yargs-parser';
+
+import commands from './command-strings';
 
 // const { ArgumentParser } = require('argparse');
 
@@ -11,27 +14,6 @@ const SEED_RANGE = 2147483648; // must be significantly smaller than Number.MAX_
 
 // parser.add_argument('--leet', { action: "store_true", help: "Make your username l33t" })
 
-export function generateName(commandArgs: string[]): string {
-  adjNoun.seed(Math.floor(Math.random() * SEED_RANGE));
-  // let args = parser.parse_args(commandArgs.slice(1))
-  const args = parser(commandArgs.slice(1), {
-    default: { leet: false, separator: ' ' },
-    boolean: ['leet'],
-    string: ['separator'],
-  });
-  // let remaindingArgs: [] = args._
-  // if (remaindingArgs.length != 0) {
-  //     console.log(`Unrecognized arguments: ${remaindingArgs.join(' ')}`) // TODO throw exception in this case
-  // }
-  const name: string[] = adjNoun();
-  if (args.leet) {
-    for (let i = 0; i < name.length; i++) {
-      name[i] = leetify(name[i], 1);
-    }
-  }
-  return name.join(args.separator);
-}
-
 const leetTable = new Map([
   ['a', '4'],
   ['e', '3'],
@@ -40,7 +22,7 @@ const leetTable = new Map([
   ['s', '5'],
 ]);
 
-function leetify(s: string, coverage: number): string {
+const leetify = (s: string, coverage: number): string => {
   const result: string[] = [];
   for (const char of s) {
     let newchar: string;
@@ -52,4 +34,30 @@ function leetify(s: string, coverage: number): string {
     result.push(newchar);
   }
   return result.join('');
+};
+
+export default function generateName(commandArgs: string[], embed: MessageEmbed): void {
+  adjNoun.seed(Math.floor(Math.random() * SEED_RANGE));
+  // let args = parser.parse_args(commandArgs.slice(1))
+  const args = parser(commandArgs.slice(1), {
+    default: { leet: false, help: false, separator: ' ' },
+    boolean: ['leet', 'help'],
+    string: ['separator'],
+  });
+  // let remaindingArgs: [] = args._
+  // if (remaindingArgs.length != 0) {
+  //     console.log(`Unrecognized arguments: ${remaindingArgs.join(' ')}`) // TODO throw exception in this case
+  // }
+  let name: string[] = adjNoun();
+  if (args.help) {
+    embed.addFields(commands.find((command) => command.name === 'name').fields);
+    return;
+  }
+  if (args.leet) {
+    // for (let i = 0; i < name.length; i++) {
+    //   name[i] = leetify(name[i], 1);
+    // }
+    name = name.map((s) => leetify(s, 1));
+  }
+  embed.setDescription(name.join(args.separator));
 }

--- a/src/discord/name-gen.ts
+++ b/src/discord/name-gen.ts
@@ -13,26 +13,44 @@ const LEET_TABLE = new Map([
 ]);
 const LEET_REPLACE_CHARS = /[aeios]/g;
 
-const leetify = (s: string, coverage: number) => s.replace(LEET_REPLACE_CHARS,
-  (char) => ((Math.random() < coverage) ? LEET_TABLE.get(char) : char));
+const leetify = (s: string, fractionLeet: number) => s.replace(LEET_REPLACE_CHARS,
+  (char) => ((Math.random() < fractionLeet) ? LEET_TABLE.get(char) : char));
 
 export default function generateName(commandArgs: string[], embed: MessageEmbed): void {
   const args = parser(commandArgs.slice(1), {
-    default: { leet: false, help: false, separator: ' ' },
+    default: {
+      leet: false,
+      help: false,
+      separator: ' ',
+      fractionLeet: 0.7,
+    },
     boolean: ['leet', 'help'],
+    number: ['fractionLeet'],
     string: ['separator'],
   });
-  // let remaindingArgs: [] = args._
-  // if (remaindingArgs.length != 0) {
-  //     console.log(`Unrecognized arguments: ${remaindingArgs.join(' ')}`)
-  // }
+  const remainingArgs = args._;
+  if (remainingArgs.length !== 0) {
+    embed.setDescription(`**Error:** Unrecognized argument(s): ${remainingArgs.join(' ')}.
+Run \`-name --help\` to get the command syntax, including a list of allowed options.`);
+    return;
+  }
+  const fractionLeet = args.fractionLeet as number;
+  // console.log(`Running generate name with leet fraction ${fractionLeet}.`);
+  if (Number.isNaN(fractionLeet)) {
+    embed.setDescription('**Error:** Fraction leet you provided is not a number');
+    return;
+  }
+  if (fractionLeet > 1 || fractionLeet < 0) {
+    embed.setDescription(`**Error:** Fraction leet you provided ${fractionLeet} is not within the valid range: [0.0 - 1.0]`);
+    return;
+  }
   let name = adjNoun();
-  if (args.help) { // Provide help message
+  if (args.help as boolean) { // Provide help message
     embed.addFields(commands.find((command) => command.name === 'name').fields);
     return;
   }
-  if (args.leet) {
-    name = name.map((s) => leetify(s, 1));
+  if (args.leet as boolean) {
+    name = name.map((s) => leetify(s, fractionLeet));
   }
-  embed.setDescription(name.join(args.separator));
+  embed.setDescription(name.join(args.separator as string));
 }

--- a/src/discord/name-gen.ts
+++ b/src/discord/name-gen.ts
@@ -29,15 +29,12 @@ export default function generateName(commandArgs: string[], embed: MessageEmbed)
   // if (remaindingArgs.length != 0) {
   //     console.log(`Unrecognized arguments: ${remaindingArgs.join(' ')}`)
   // }
-  let name: string[] = adjNoun();
+  let name = adjNoun();
   if (args.help) { // Provide help message
     embed.addFields(commands.find((command) => command.name === 'name').fields);
     return;
   }
   if (args.leet) {
-    // for (let i = 0; i < name.length; i++) {
-    //   name[i] = leetify(name[i], 1);
-    // }
     name = name.map((s) => leetify(s, 1));
   }
   embed.setDescription(name.join(args.separator));

--- a/src/discord/name-gen.ts
+++ b/src/discord/name-gen.ts
@@ -4,8 +4,6 @@ import parser from 'yargs-parser';
 
 import commands from './command-strings';
 
-const SEED_RANGE = 2147483648; // must be significantly smaller than Number.MAX_SAFE_INTEGER or adj-noun may give undefined stuff on fractional values
-
 const LEET_TABLE = new Map([
   ['a', '4'],
   ['e', '3'],
@@ -19,7 +17,6 @@ const leetify = (s: string, coverage: number) => s.replace(LEET_REPLACE_CHARS,
   (char) => ((Math.random() < coverage) ? LEET_TABLE.get(char) : char));
 
 export default function generateName(commandArgs: string[], embed: MessageEmbed): void {
-  adjNoun.seed(Math.floor(Math.random() * SEED_RANGE));
   const args = parser(commandArgs.slice(1), {
     default: { leet: false, help: false, separator: ' ' },
     boolean: ['leet', 'help'],

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,11 @@
 import sqlite3 from 'sqlite3';
 import { open, Database } from 'sqlite';
+import adjNoun from 'adj-noun';
 
 import config from './config.json';
 import Bot from './discord/Bot';
+
+const SEED_RANGE = 2147483648; // must be significantly smaller than Number.MAX_SAFE_INTEGER or adj-noun may give undefined stuff on fractional values
 
 const initDatabase = async (db: Database<sqlite3.Database, sqlite3.Statement>) => {
   console.log('Database is empty, initializing database for the first time...');
@@ -12,6 +15,9 @@ const initDatabase = async (db: Database<sqlite3.Database, sqlite3.Statement>) =
 };
 
 const init = async () => {
+  const seed = Math.floor(Math.random() * SEED_RANGE);
+  console.log(`Using seed ${seed} for adj-noun`);
+  adjNoun.seed(seed);
   const db = await open({
     filename: config.sqliteDbPath,
     driver: sqlite3.Database,

--- a/src/types/adj-noun.d.ts
+++ b/src/types/adj-noun.d.ts
@@ -1,0 +1,9 @@
+declare function adjNoun(): string[]; // default export (actually named next in JS module but used module name to increase clarity)
+declare namespace adjNoun {
+  export function next(): string[]; // same function as the default export above, to reflect actual content in JS module.
+  export function seed(newSeed: number): boolean;
+  export function adjPrime(newPrime: number): boolean;
+  export function nounPrime(newPrime: number): boolean;
+}
+
+export = adjNoun;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,9 @@
     "sourceMap": true,
     "outDir": "dist",
     "baseUrl": ".",
+    "typeRoots": [
+      "src/types/*"
+    ],
     "paths": {
       "*": [
         "node_modules/*",


### PR DESCRIPTION
Highlights
- Made my name randomizer pass all ESLint checks.
- Type declaration for `adj-noun` module
- Advanced `--fraction-leet` option to control the probability that letters like a, e, i, o, s gets converted into 4, 3, 1, 0, 5 respectively.
- Documented all command options through the help interface: `-name --help`