### PR TITLE
Mini CTF fixes

### DIFF
--- a/src/discord/Bot.ts
+++ b/src/discord/Bot.ts
@@ -16,7 +16,7 @@ export default class Bot {
 
   private readonly db: Database<sqlite3.Database, sqlite3.Statement>;
 
-  public checkingFlag: Set<User>;
+  public checkingFlag: Set<string>;
 
   private flags: Map<string, Buffer>;
 
@@ -24,7 +24,7 @@ export default class Bot {
     this.client = new Client();
     this.config = config;
     this.db = db;
-    this.checkingFlag = new Set<User>();
+    this.checkingFlag = new Set<string>();
     this.flags = new Map<string, Buffer>();
     challenges.forEach((challenge: Challenge) => {
       this.flags.set(challenge.name, Buffer.from(challenge.flag));

--- a/src/discord/functions.ts
+++ b/src/discord/functions.ts
@@ -1,5 +1,5 @@
 import { timingSafeEqual } from 'crypto';
-import { User, Message, MessageEmbed } from 'discord.js';
+import { Message, MessageEmbed } from 'discord.js';
 import { Database } from 'sqlite';
 import sqlite3 from 'sqlite3';
 import roles from './roles';
@@ -11,11 +11,11 @@ export const formatEmbed = ($embed: MessageEmbed) => {
   $embed
     .setColor(8388608)
     .setTitle('NSA')
-    .setURL('http://github.com/acmucsd-cyber/nsa')
+    .setURL('https://github.com/acmucsd-cyber/nsa')
     .setFooter("I'm Watching You 👁️");
 };
 
-export const flag = async (db: Database<sqlite3.Database, sqlite3.Statement>, flagUsers: Set<User>, realFlag: Buffer, commandArgs: string[], message: Message, embed: MessageEmbed) => {
+export const flag = async (db: Database<sqlite3.Database, sqlite3.Statement>, flagUsers: Set<string>, realFlag: Buffer, commandArgs: string[], message: Message, embed: MessageEmbed) => {
   if (commandArgs.length === 2) {
     embed.setDescription('Please make sure to include the challenge name **as well as** the flag you got.');
     return;
@@ -24,7 +24,7 @@ export const flag = async (db: Database<sqlite3.Database, sqlite3.Statement>, fl
     embed.setDescription('Too many arguments provided. Please put exactly one flag after the challenge name.');
     return;
   }
-  if (flagUsers.has(message.author)) {
+  if (flagUsers.has(message.author.id)) {
     embed.setDescription('Please wait for your last flag submission to be processed first.');
     return;
   }
@@ -50,9 +50,9 @@ export const flag = async (db: Database<sqlite3.Database, sqlite3.Statement>, fl
     checkFlags().catch((error) => {
       console.error(`Failed to check flag for user ${message.author.tag}`);
       console.error(error);
-    }).finally(() => { flagUsers.delete(message.author); });
+    }).finally(() => { flagUsers.delete(message.author.id); });
   }, 1500);
-  flagUsers.add(message.author);
+  flagUsers.add(message.author.id);
   embed.setDescription('Please wait while your flag is checked...');
 };
 

--- a/src/discord/functions.ts
+++ b/src/discord/functions.ts
@@ -17,7 +17,7 @@ export const formatEmbed = ($embed: MessageEmbed) => {
 
 export const flag = async (db: Database<sqlite3.Database, sqlite3.Statement>, flagUsers: Set<User>, realFlag: Buffer, commandArgs: string[], message: Message, embed: MessageEmbed) => {
   if (commandArgs.length === 2) {
-    embed.setDescription('Please make sure to include the challenge name **as well as** the flag you get.');
+    embed.setDescription('Please make sure to include the challenge name **as well as** the flag you got.');
     return;
   }
   if (commandArgs.length > 3) {
@@ -28,7 +28,7 @@ export const flag = async (db: Database<sqlite3.Database, sqlite3.Statement>, fl
     embed.setDescription('Please wait for your last flag submission to be processed first.');
     return;
   }
-  if (await db.get('SELECT * from ctf_solves WHERE user_id = ? and challenge_name = ?',
+  if (await db.get('SELECT * FROM ctf_solves WHERE user_id = ? AND challenge_name = ?',
     [message.author.id, commandArgs[1]]) !== undefined) {
     embed.setDescription('You already solved this challenge.');
     return;
@@ -47,7 +47,7 @@ export const flag = async (db: Database<sqlite3.Database, sqlite3.Statement>, fl
     await message.channel.send(msg);
   };
   setTimeout(() => {
-    checkFlags().then(() => { }).catch((error) => {
+    checkFlags().catch((error) => {
       console.error(`Failed to check flag for user ${message.author.tag}`);
       console.error(error);
     }).finally(() => { flagUsers.delete(message.author); });


### PR DESCRIPTION
Minor changes to the mini CTF code, including an http -> https link change and `Bot.checkingFlag`

`Bot.checkingFlag` describes the set of users the bot is currently checking flag for to prevent brute forcing. It enforces the 1.5 second delay between flag checks by the same user. It used to be of type `Set<User>` (a set of user objects) and this PR changes it to `Set<string>` (a set of user ID strings).

The change is consistent with the preferred way of comparing between users (compare by ID not object reference). If Discord.JS used different user objects for the same user during the uptime of the bot this will allow a single user to brute force flags. (the same user now compares different in the `Bot.checkingFlag` set) However, I cannot find a proof of concept for this type of brute force, since the current version of Discord.js seems to always return the same user reference for the same user. Despite that, we should not rely on this behavior.